### PR TITLE
fix: js: call handleUpdate event on modal

### DIFF
--- a/css/bootstrap-material-datepicker.css
+++ b/css/bootstrap-material-datepicker.css
@@ -32,4 +32,3 @@ span[class^=mdi-], [class*=" mdi-"] { position: relative; top: 7px; }
 .dtp .dtp-minute-hand { width: 2px; margin-left: -1px; }
 .dtp .dtp-hand.on { background: #8BC34A; }
 .dtp-clock-center { width: 15px; height: 15px; background: #757575; border-radius: 50%; position: absolute; z-index: 50; }
-.dtp .modal-backdrop.fade.in { min-height: 100% !important; }

--- a/js/bootstrap-material-datepicker.js
+++ b/js/bootstrap-material-datepicker.js
@@ -776,6 +776,7 @@
 					if(this.params.time === true)
 					{
 						this.initHours();
+						$('#' + this.name).modal('handleUpdate');
 					}
 					else
 					{
@@ -784,7 +785,7 @@
 					}
 					break;
 				case 1: 
-					this.initMinutes(); break;
+					this.initMinutes(); $('#' + this.name).modal('handleUpdate'); break;
 				case 2: 
 					this.setElementValue();
 					$('#' + this.name).modal('hide'); break;
@@ -797,8 +798,8 @@
 				switch(this.currentView)
 				{
 					case 0: $('#' + this.name).modal('hide'); break;
-					case 1: this.initDate(); break;
-					case 2: this.initHours(); break;
+					case 1: this.initDate(); $('#' + this.name).modal('handleUpdate'); break;
+					case 2: this.initHours(); $('#' + this.name).modal('handleUpdate'); break;
 				}
 			}
 			else


### PR DESCRIPTION
Modals with dynamic content height should call handleUpdate() when content updates.

ref: 
* https://github.com/twbs/bootstrap/issues/15106
* https://github.com/twbs/bootstrap/issues/15483

fixes: modal-backdrop height curtailed to window-height

note: this is the right way to do it, it seems; instead of trying to hard-code as css.
tested and working on Chrome 39 (39.0.2171.71) and Firefox 38.0.

